### PR TITLE
Feature/init sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: java
 
 before_cache:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ In our implementation we opted to use Amazon Kinesis Client with DynamoDB Stream
 * Java 8
 * Gradlew 5.3.1
 * Kafka Connect Framework >= 2.1.1
-* Amazon Kinesis Client 1.9.1
-* DynamoDB Streams Kinesis Adapter 1.5.2
+* Amazon Kinesis Client 1.13.1
+* DynamoDB Streams Kinesis Adapter 1.5.3
 
 ## Documentation
 * [Getting started](docs/getting-started.md)
@@ -44,6 +44,7 @@ In our implementation we opted to use Amazon Kinesis Client with DynamoDB Stream
   * However you will only encounter this issue by running lots of tasks on one machine with really high load.
 
 * Synced(Source) DynamoDB table unit capacity must be large enough to ensure `INIT_SYNC` to be finished in around 16 hours. Otherwise there is a risk `INIT_SYNC` being restarted just as soon as it's finished because DynamoDB Streams store change events only for 24 hours.
+  * `INIT_SYNC` can be skipped with `init.sync.skip=true` configuration
 
 * Required AWS roles:
 ```json

--- a/docs/details.md
+++ b/docs/details.md
@@ -13,6 +13,8 @@ This connector can sync multiple DynamoDB tables at the same time and it does so
 
 `INIT_SYNC` is a process when all existing table data is scanned and pushed into Kafka destination topic. Usually this happens only once after source task for specific table is started for the first time. But it can be repeated in case of unexpected issues, e.g. if source connector was down for long period of time and it is possible that it has missed some of the change events from the table stream (DynamoDB streams store data for 24 hours only). 
 
+Using `init.sync.skip` will skip this process and the connector will only ever read from the LATEST position in the stream.
+
 ### 3. "SYNC"
 
 Once `INIT_SYNC` is finished source task switches into DynamoDB Streams consumer state. There all changes that happen to the source table are represented in this stream and copied over to the Kafka's destination topic. Consumers of this topic can recreate full state of the source table at any given time.

--- a/docs/options.md
+++ b/docs/options.md
@@ -36,6 +36,7 @@
     "tasks.max": "1",
 
     "init.sync.delay.period": 60,
+    "init.sync.skip": false,
     "connect.dynamodb.rediscovery.period": "60000"
 }
 ```
@@ -52,6 +53,8 @@
 `tasks.max` - **MUST** always exceed number of tables found for tracking. If max tasks count is lower then found tables count, no tasks will be started!
 
 `init.sync.delay.period` - time interval in seconds. Defines how long `INIT_SYNC` should delay execution before starting. This is used to give time for Kafka Connect tasks to calm down after rebalance (Since multiple tasks rebalances can happen in quick succession and this would mean more duplicated data since `INIT_SYNC` process won't have time mark it's progress). 
+
+`init.sync.skip` - boolean to determine whether to start the connector reading the entire table or from the latest offset.
 
 `connect.dynamodb.rediscovery.period` - time interval in milliseconds. Defines how often connector should try to find new DynamoDB tables (or detect removed ones). If changes are found tasks are automatically reconfigured.
 

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-resourcegroupstaggingapi:1.11.551'
 
     compile group: 'org.apache.kafka', name: 'connect-api', version: "${rootProject.ext.kafkaConnectApiVersion}"
-    compile group: 'com.amazonaws', name: 'amazon-kinesis-client', version: '1.9.1'
-    compile group: 'com.amazonaws', name: 'dynamodb-streams-kinesis-adapter', version: '1.5.2'
+    compile group: 'com.amazonaws', name: 'amazon-kinesis-client', version: '1.13.3'
+    compile group: 'com.amazonaws', name: 'dynamodb-streams-kinesis-adapter', version: '1.5.3'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.11.877'
 }

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceConnectorConfig.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceConnectorConfig.java
@@ -17,6 +17,11 @@ public class DynamoDBSourceConnectorConfig extends AbstractConfig {
 	public static final String SRC_INIT_SYNC_DELAY_DISPLAY = "INIT_SYNC delay";
 	public static final int SRC_INIT_SYNC_DELAY_DEFAULT = 60;
 
+	public static final String SRC_INIT_SYNC_SKIP_CONFIG = "init.sync.skip";
+	public static final String SRC_INIT_SYNC_SKIP_DOC = "Define whether to skip INIT_SYNC of table.";
+	public static final String SRC_INIT_SYNC_SKIP_DISPLAY = "Skip INIT_SYNC";
+	public static final boolean SRC_INIT_SYNC_SKIP_DEFAULT = false;
+
   	public static final String AWS_REGION_CONFIG = "aws.region";
 	public static final String AWS_REGION_DOC = "Define AWS region.";
 	public static final String AWS_REGION_DISPLAY = "Region";
@@ -204,12 +209,21 @@ public class DynamoDBSourceConnectorConfig extends AbstractConfig {
 						ConfigDef.Width.MEDIUM,
 						DST_TOPIC_PREFIX_DISPLAY)
 
+				.define(SRC_INIT_SYNC_SKIP_CONFIG,
+						ConfigDef.Type.BOOLEAN,
+						SRC_INIT_SYNC_SKIP_DEFAULT,
+						ConfigDef.Importance.LOW,
+						SRC_INIT_SYNC_SKIP_DOC,
+						CONNECTOR_GROUP, 2,
+						ConfigDef.Width.MEDIUM,
+						SRC_INIT_SYNC_SKIP_DISPLAY)
+
 				.define(SRC_INIT_SYNC_DELAY_CONFIG,
 						ConfigDef.Type.INT,
 						SRC_INIT_SYNC_DELAY_DEFAULT,
 						ConfigDef.Importance.LOW,
 						SRC_INIT_SYNC_DELAY_DOC,
-						CONNECTOR_GROUP, 2,
+						CONNECTOR_GROUP, 3,
 						ConfigDef.Width.MEDIUM,
 						SRC_INIT_SYNC_DELAY_DISPLAY)
 
@@ -265,6 +279,10 @@ public class DynamoDBSourceConnectorConfig extends AbstractConfig {
 
 	public long getRediscoveryPeriod() {
 		return getLong(REDISCOVERY_PERIOD_CONFIG);
+	}
+
+	public boolean getInitSyncSkip() {
+		return (boolean)get(SRC_INIT_SYNC_SKIP_CONFIG);
 	}
 
 	public int getInitSyncDelay() {

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
@@ -177,7 +177,7 @@ public class DynamoDBSourceTask extends SourceTask {
         } else {
             LOGGER.debug("No stored offset found for table: {}", tableDesc.getTableName());
             sourceInfo = new SourceInfo(tableDesc.getTableName(), clock);
-            sourceInfo.startInitSync(); // InitSyncStatus always needs to run after adding new table
+            sourceInfo.startInitSync();
         }
     }
 

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/InitSyncStatus.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/InitSyncStatus.java
@@ -3,5 +3,6 @@ package com.trustpilot.connector.dynamodb;
 public enum InitSyncStatus {
     UNDEFINED,
     RUNNING,
-    FINISHED
+    FINISHED,
+    SKIPPED
 }

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/SourceInfo.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/SourceInfo.java
@@ -71,6 +71,14 @@ public class SourceInfo {
         lastInitSyncEnd = Instant.now(clock);
     }
 
+    public void skipInitSync() {
+        initSyncStatus = InitSyncStatus.SKIPPED;
+        lastInitSyncStart = Instant.ofEpochSecond(0);
+        lastInitSyncEnd = Instant.ofEpochSecond(0);;
+        exclusiveStartKey = null;
+        initSyncCount = 0L;
+    }
+
     private static final Schema STRUCT_SCHEMA = SchemaBuilder.struct()
                                                              .name(SchemaNameAdjuster
                                                                            .defaultAdjuster()

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclNoopCloudWatch.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclNoopCloudWatch.java
@@ -95,6 +95,11 @@ public class KclNoopCloudWatch implements AmazonCloudWatch {
     }
 
     @Override
+    public GetMetricStreamResult getMetricStream(GetMetricStreamRequest getMetricStreamRequest) {
+        return null;
+    }
+
+    @Override
     public GetMetricWidgetImageResult getMetricWidgetImage(GetMetricWidgetImageRequest getMetricWidgetImageRequest) {
         return null;
     }
@@ -120,6 +125,11 @@ public class KclNoopCloudWatch implements AmazonCloudWatch {
     }
 
     @Override
+    public PutCompositeAlarmResult putCompositeAlarm(PutCompositeAlarmRequest putCompositeAlarmRequest) {
+        return null;
+    }
+
+    @Override
     public PutMetricAlarmResult putMetricAlarm(PutMetricAlarmRequest putMetricAlarmRequest) {
         return null;
     }
@@ -130,7 +140,22 @@ public class KclNoopCloudWatch implements AmazonCloudWatch {
     }
 
     @Override
+    public PutMetricStreamResult putMetricStream(PutMetricStreamRequest putMetricStreamRequest) {
+        return null;
+    }
+
+    @Override
     public SetAlarmStateResult setAlarmState(SetAlarmStateRequest setAlarmStateRequest) {
+        return null;
+    }
+
+    @Override
+    public StartMetricStreamsResult startMetricStreams(StartMetricStreamsRequest startMetricStreamsRequest) {
+        return null;
+    }
+
+    @Override
+    public StopMetricStreamsResult stopMetricStreams(StopMetricStreamsRequest stopMetricStreamsRequest) {
         return null;
     }
 
@@ -170,6 +195,11 @@ public class KclNoopCloudWatch implements AmazonCloudWatch {
     }
 
     @Override
+    public DeleteMetricStreamResult deleteMetricStream(DeleteMetricStreamRequest deleteMetricStreamRequest) {
+        return null;
+    }
+
+    @Override
     public GetDashboardResult getDashboard(GetDashboardRequest getDashboardRequest) {
         return null;
     }
@@ -186,6 +216,11 @@ public class KclNoopCloudWatch implements AmazonCloudWatch {
 
     @Override
     public ListDashboardsResult listDashboards(ListDashboardsRequest listDashboardsRequest) {
+        return null;
+    }
+
+    @Override
+    public ListMetricStreamsResult listMetricStreams(ListMetricStreamsRequest listMetricStreamsRequest) {
         return null;
     }
 

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclWorker.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclWorker.java
@@ -10,6 +10,7 @@ public interface KclWorker {
                String tableName,
                String taskid,
                String endpoint,
+               Boolean isSkipSync,
                BillingMode kclTablebillingMode);
 
     void stop();

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.time.Duration;

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
@@ -884,7 +884,7 @@ public class DynamoDBSourceTaskTests {
         HashMap<String, Object> offset = new HashMap<>();
         offset.put("table_name", tableName);
         offset.put("init_sync_state", "SKIPPED");
-        offset.put("init_sync_start", Instant.parse("2001-01-02T00:00:00.00Z").toEpochMilli());
+        offset.put("init_sync_start", Instant.parse("1970-01-01T00:00:00Z").toEpochMilli());
 
         DynamoDBSourceTask task = new SourceTaskBuilder()
                 .withOffset(offset)

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/kcl/KclWorkerImplTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/kcl/KclWorkerImplTests.java
@@ -35,6 +35,7 @@ public class KclWorkerImplTests {
         String tableName = "testTableName1";
         String taskId = "task1";
         String serviceEndpoint = "http://localhost:8000";
+        Boolean isSyncSkip = false;
         BillingMode kclTableBillingMode = BillingMode.PROVISIONED;
 
         AmazonDynamoDB dynamoDBClient = Mockito.mock(AmazonDynamoDB.class);
@@ -43,7 +44,7 @@ public class KclWorkerImplTests {
         when(dynamoDBClient.describeTable(ArgumentMatchers.<DescribeTableRequest>any())).thenReturn(result);
 
         // Act
-        KinesisClientLibConfiguration clientLibConfiguration = kclWorker.getClientLibConfiguration(tableName, taskId, dynamoDBClient, serviceEndpoint, kclTableBillingMode);
+        KinesisClientLibConfiguration clientLibConfiguration = kclWorker.getClientLibConfiguration(tableName, taskId, dynamoDBClient, serviceEndpoint, isSyncSkip, kclTableBillingMode);
 
         // Assert
         assertEquals("datalake-KCL-testTableName1", clientLibConfiguration.getApplicationName());


### PR DESCRIPTION
- Bringing upstream commit in. This upgrades `amazon-kinesis-client` and `dynamodb-streams-kinesis-adapter` and adds some CloudWatch metrics.
- Extending connector to include `init.sync.skip` flag. This optional flag will skip the initial load of dynamodb and read from `LATEST` on the DynamoDBStream.