### PR TITLE
handle no offset init.sync.skip

### DIFF
--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
@@ -177,7 +177,11 @@ public class DynamoDBSourceTask extends SourceTask {
         } else {
             LOGGER.debug("No stored offset found for table: {}", tableDesc.getTableName());
             sourceInfo = new SourceInfo(tableDesc.getTableName(), clock);
-            sourceInfo.startInitSync();
+            if (initSyncSkip) {
+                sourceInfo.skipInitSync();
+            } else {
+                sourceInfo.startInitSync();
+            }
         }
     }
 

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
@@ -876,6 +876,25 @@ public class DynamoDBSourceTaskTests {
     }
 
     @Test
+    public void initSyncIsSkippedWithNoOffsetOnStart() throws InterruptedException {
+        configs.put("init.sync.skip", "true");
+        // Arrange
+        DynamoDBSourceTask task = new SourceTaskBuilder()
+                .withOffset(null)
+                .buildTask();
+
+        // Act
+        task.start(configs);
+
+        // Assert
+        SourceInfo sourceInfo = task.getSourceInfo();
+        assertEquals(tableName, sourceInfo.tableName);
+        assertEquals(InitSyncStatus.SKIPPED, sourceInfo.initSyncStatus);
+        assertEquals(Instant.parse("1970-01-01T00:00:00Z"), sourceInfo.lastInitSyncStart);
+        assertEquals(Instant.parse("1970-01-01T00:00:00Z"), sourceInfo.lastInitSyncEnd);
+    }
+
+    @Test
     public void sourceInfoOfSkippedInitSyncIsLoadedFromOffsetOnStart() throws InterruptedException {
         configs.put("init.sync.skip", "true");
         // Arrange


### PR DESCRIPTION
`init.sync.skip` was not respected starting from scratch without an offset. An offset is present if the connector has been connected to a dynamo table in any capacity (KCL table still exists/internal topic has been written to).

This PR addresses using `init.sync.skip` from start() on a new table + topic.