### PR TITLE
Feature/publish old image

### DIFF
--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
@@ -257,6 +257,7 @@ public class DynamoDBSourceTask extends SourceTask {
             result.add(converter.toSourceRecord(sourceInfo,
                                                 Envelope.Operation.READ,
                                                 record,
+                                                null,
                                                 sourceInfo.lastInitSyncStart,
                                                 null,
                                                 null));
@@ -275,6 +276,7 @@ public class DynamoDBSourceTask extends SourceTask {
             result.add(converter.toSourceRecord(sourceInfo,
                                                 Envelope.Operation.READ,
                                                 lastRecord,
+                                                null,
                                                 sourceInfo.lastInitSyncStart,
                                                 null,
                                                 null));
@@ -364,9 +366,12 @@ public class DynamoDBSourceTask extends SourceTask {
                     attributes = dynamoDbRecord.getDynamodb().getKeys();
                 }
 
+                Map<String, AttributeValue> oldImage = dynamoDbRecord.getDynamodb().getOldImage();
+
                 SourceRecord sourceRecord = converter.toSourceRecord(sourceInfo,
                                                                      op,
                                                                      attributes,
+                                                                     oldImage,
                                                                      arrivalTimestamp.toInstant(),
                                                                      dynamoDBRecords.getShardId(),
                                                                      record.getSequenceNumber());

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/Envelope.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/Envelope.java
@@ -57,6 +57,10 @@ public final class Envelope {
          */
         public static final String DOCUMENT = "document";
         /**
+         * The {@code oldDocument} field is used to store the state of a record before an operation.
+         */
+        public static final String OLD_DOCUMENT = "oldDocument";
+        /**
          * The {@code op} field is used to store the kind of operation on a record.
          */
         public static final String OPERATION = "op";

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/Envelope.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/Envelope.java
@@ -59,7 +59,7 @@ public final class Envelope {
         /**
          * The {@code oldDocument} field is used to store the state of a record before an operation.
          */
-        public static final String OLD_DOCUMENT = "oldDocument";
+        public static final String OLD_DOCUMENT = "old_document";
         /**
          * The {@code op} field is used to store the kind of operation on a record.
          */

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/utils/RecordConverter.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/utils/RecordConverter.java
@@ -52,6 +52,7 @@ public class RecordConverter {
                                    .name(SchemaNameAdjuster.DEFAULT.adjust( "com.trustpilot.connector.dynamodb.envelope"))
                                    .field(Envelope.FieldName.VERSION, Schema.STRING_SCHEMA)
                                    .field(Envelope.FieldName.DOCUMENT, DynamoDbJson.schema())
+                                    .field(Envelope.FieldName.OLD_DOCUMENT, DynamoDbJson.schema())
                                    .field(Envelope.FieldName.SOURCE, SourceInfo.structSchema())
                                    .field(Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA)
                                    .field(Envelope.FieldName.TIMESTAMP, Schema.INT64_SCHEMA)

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/utils/RecordConverter.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/utils/RecordConverter.java
@@ -62,6 +62,7 @@ public class RecordConverter {
             SourceInfo sourceInfo,
             Envelope.Operation op,
             Map<String, AttributeValue> attributes,
+            Map<String, AttributeValue> oldImage,
             Instant arrivalTimestamp,
             String shardId,
             String sequenceNumber) throws Exception {
@@ -77,6 +78,7 @@ public class RecordConverter {
 
         // getUnmarshallItems from Dynamo Document
         Map<String, Object> unMarshalledItems = ItemUtils.toSimpleMapValue(attributes);
+        Map<String, Object> unMarshalledOldItems = ItemUtils.toSimpleMapValue(oldImage);
 
         // Leveraging offsets to store shard and sequence number with each item pushed to Kafka.
         // This info will only be used to update `shardRegister` and won't be used to reset state after restart
@@ -106,6 +108,7 @@ public class RecordConverter {
         Struct valueData = new Struct(valueSchema)
                 .put(Envelope.FieldName.VERSION, sourceInfo.version)
                 .put(Envelope.FieldName.DOCUMENT, objectMapper.writeValueAsString(unMarshalledItems))
+                .put(Envelope.FieldName.OLD_DOCUMENT, objectMapper.writeValueAsString(unMarshalledOldItems))
                 .put(Envelope.FieldName.SOURCE, SourceInfo.toStruct(sourceInfo))
                 .put(Envelope.FieldName.OPERATION, op.code())
                 .put(Envelope.FieldName.TIMESTAMP, arrivalTimestamp.toEpochMilli());

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/utils/RecordConverterTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/utils/RecordConverterTests.java
@@ -82,6 +82,7 @@ public class RecordConverterTests {
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
                 getAttributes(),
+                getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
                 "testSequenceNumberID1"
@@ -101,6 +102,7 @@ public class RecordConverterTests {
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
                 getAttributes(),
+                getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
                 "testSequenceNumberID1"
@@ -119,6 +121,7 @@ public class RecordConverterTests {
         SourceRecord record = converter.toSourceRecord(
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
+                getAttributes(),
                 getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
@@ -142,6 +145,7 @@ public class RecordConverterTests {
         SourceRecord record = converter.toSourceRecord(
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
+                getAttributes(),
                 getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
@@ -168,6 +172,7 @@ public class RecordConverterTests {
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
                 getAttributes(),
+                getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
                 "testSequenceNumberID1"
@@ -193,6 +198,7 @@ public class RecordConverterTests {
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
                 getAttributes(),
+                getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
                 "testSequenceNumberID1"
@@ -215,6 +221,7 @@ public class RecordConverterTests {
         SourceRecord record = converter.toSourceRecord(
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
+                getAttributesWithInvalidAvroCharacters(),
                 getAttributesWithInvalidAvroCharacters(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
@@ -241,6 +248,7 @@ public class RecordConverterTests {
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
                 getAttributesWithInvalidAvroCharacters(),
+                getAttributesWithInvalidAvroCharacters(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
                 "testSequenceNumberID1"
@@ -266,6 +274,7 @@ public class RecordConverterTests {
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
                 getAttributesWithInvalidAvroCharacters(),
+                getAttributesWithInvalidAvroCharacters(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
                 "testSequenceNumberID1"
@@ -287,6 +296,7 @@ public class RecordConverterTests {
         SourceRecord record = converter.toSourceRecord(
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
+                getAttributes(),
                 getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
@@ -310,6 +320,7 @@ public class RecordConverterTests {
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
                 getAttributes(),
+                getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",
                 "testSequenceNumberID1"
@@ -328,6 +339,7 @@ public class RecordConverterTests {
         SourceRecord record = converter.toSourceRecord(
                 getSourceInfo(table),
                 Envelope.Operation.forCode("r"),
+                getAttributes(),
                 getAttributes(),
                 Instant.parse("2001-01-02T00:00:00.00Z"),
                 "testShardID1",


### PR DESCRIPTION
### Ticket 🎟

</br>

### What ⁉️
Adding support to publish the old image in dynamo streams that have both new and old images. This enables more complex flows for Dynamo CDC.

New field has been added to the payload named "old_document" which will be null if that field isn't there. This should be a backwards compatible change since no other fields have been modified.

### Why ⁉️
This enables easy diffing of fields that have been modified.

### How ⁉️
Added the field, tested changes manually on a dev cluster to verify behavior

### How to review and test 📱
tbd

</br>

### Checklist ✅
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests are passing locally
